### PR TITLE
RFC: new `printfarm` folder for ready-to-print gcode?

### DIFF
--- a/printfarm/MP10/README.md
+++ b/printfarm/MP10/README.md
@@ -1,0 +1,46 @@
+## Quickstart
+
+1. Download the newest `mp10-gcode-...` zip bundle.
+1. Print `do-mesh-compensation.gcode` after power-on.
+1. Print any gcode files you like!
+1. Back to the main [README](https://github.com/CRASHSpace/COVID-19-3dprints/blob/master/README.md) for drop-off instructions.
+
+### _(optional)_ Tuning slicer settings?
+
+1. Download and import the slicer-settings zip bundle for your slicer.
+1. Change, slice, print, evaluate, repeat!
+
+#### :cry: But I don't see mine here!
+
+Create an [issue](https://github.com/CRASHSpace/COVID-19-3dprints/issues/new) to request support for your slicer!
+
+## Updates
+
+* YYYY-MM-DD
+  * eg: Added gcode for four-shields-one-print
+* YYY-MM-DD
+  * eg: Added gcode for MaterialXYZ filament
+
+## What else is here?
+
+### G-code files
+
+A zip bundle of gcode ready for immediate printing on your MP10.
+
+  * `do-mesh-calibration.gcode`
+  * `face-shield-budmen-v5-pla.gcode`
+  * _et al_
+  * _more on PR or demand_
+
+### Slicer profiles
+
+A zip bundle of files for adding the MP10 to your slicer.
+
+  * printer model to import
+  * slicer profile to import
+  * guide for importing printers and profiles
+
+### Detailed help
+
+* `slicer-settings-generic.txt` -- _plain text `key = value` pairs of settings for the MP10's size and kinematics_
+* `troubleshooting-and-diagnostics.md` -- _FAQs, firmware and hardware information_

--- a/printfarm/MP10/slicer-settings-generic.txt
+++ b/printfarm/MP10/slicer-settings-generic.txt
@@ -1,0 +1,46 @@
+# Comment: this file uses
+#   a '.' to group related settings
+#   one 'key = value' entry per line
+#   'snake_casing' for multiword keys
+#   plain text for values
+
+# Printer mechanics
+printer.width = 300
+printer.depth = 300
+printer.height = 400
+
+printer.build_plate_shape = rectangular
+printer.origin_at_center = false
+printer.heated_bed = true
+printer.heated_build_volume = false
+printer.gcode_flavor = marlin
+
+printer.printhead.xmin = -44
+printer.printhead.ymin = -34
+printer.printhead.xmax = 38
+printer.printhead.ymax = 34
+printer.printhead.gantry_height = 30
+
+printer.number_of_extruders = 1
+printer.shared_heater = false
+
+printer.extruder1.material_diameter = 1.75
+printer.extruder1.nozzle_offset_x = 0
+printer.extruder1.nozzle_offset_y = 0
+printer.extruder1.cooling_fan_number = 0
+
+# Slicer profile
+profile.quality.layer_height = 20
+profile.quality.initial_layer_height = 24
+
+profile.material.printing_temperature = 220
+profile.material.build_plate_temperature = 60
+profile.material.flow = 130
+profile.material.initial_layer_flow = 150
+
+profile.speed.print_speed = 50
+profile.speed.wall_speed = 25
+profile.speed.initial_layer_speed = 20
+
+profile.adhesion.type = skirt
+profile.adhesion.skirt.length_min = 400

--- a/printfarm/MP10/troubleshooting-and-diagnostics.md
+++ b/printfarm/MP10/troubleshooting-and-diagnostics.md
@@ -1,0 +1,16 @@
+## Quickstart
+
+1. Are you in the CRASHspace Slack space? See the main [COVID19 response page](https://blog.crashspace.org/covid/) for info.
+
+## FAQs
+
+Q: How do I ask a question?
+A:
+* in Slack: see the main [COVID19 response page](https://blog.crashspace.org/covid/) for info
+* in Github: create a new issue
+
+## Diagnostics
+
+
+
+## Work notes


### PR DESCRIPTION
# Motivation

It may be useful for CRASHers who adopted the Monoprice MP10 units to have no-slice, ready-to-print gcode files. We could place these generated files in a folder for the printfarm and CRASHers (and other MP10 owners alike) can just download, print, and drop off.

_eg, as in the README, also **includes automatic mesh-calibration**_

> ## Quickstart
> 1. Download the newest `mp10-gcode-...` zip bundle.
> 1. Print `do-mesh-compensation.gcode` after power-on.
> 1. Print any gcode files you like!
> 1. Back to the main [README](https://github.com/CRASHSpace/COVID-19-3dprints/blob/master/README.md) for drop-off instructions.

# Implementation

Here's a sketch of what a new `printfarm` folder might look like:

```
📁 images
📂 printfarm
  📂 MP10
    🗄️ mp10-gcode-covid19-ppe.zip
    🗄️ mp10-slicer-settings-cura.zip
    📄 README.md
    📄 slicer-settings-generic.txt
    📄 troubleshooting-and-diagnostics.md
```

# What should be easy and prioritized

- For CRASH farm printers
  - Time-and-effort needed from unboxing to first-print
  - Tuning the slicer settings
- For GitHub contributors
  - Add more 3D tools like Slic3r
  - Add gcode variants for more filament materials (eg HTPLA, PETG)
  - Add gcode variants for more printer upgrade options (eg extruder, nozzle diameter, hotend)

# RFC 1: worthwhile priorities?

Should we add, remove, or adjust anything about the what-should-be-easy list?

# RFC 2: feasible approach?

Should we add, remove, or adjust anything about how the approach shares gcode and settings and offers help?